### PR TITLE
Fix multi-node cluster import failure

### DIFF
--- a/tendrl/node_agent/ceph_integration/flows/import_cluster.py
+++ b/tendrl/node_agent/ceph_integration/flows/import_cluster.py
@@ -37,6 +37,9 @@ class ImportCluster(BaseFlow):
                            }
                     if "etcd_client" in job['parameters']:
                         del job['parameters']['etcd_client']
+                    if "manager" in job['parameters']:
+                        del job['parameters']['manager']
+
                     self.etcd_client.write("/queue/%s" % uuid.uuid4(),
                                            json.dumps(job))
         if curr_node_id in node_list:

--- a/tendrl/node_agent/gluster_integration/flows/import_cluster.py
+++ b/tendrl/node_agent/gluster_integration/flows/import_cluster.py
@@ -34,6 +34,9 @@ class ImportCluster(BaseFlow):
                            "type": "node"}
                     if "etcd_client" in job['parameters']:
                         del job['parameters']['etcd_client']
+                    if "manager" in job['parameters']:
+                        del job['parameters']['manager']
+
                     self.etcd_client.write("/queue/%s" % uuid.uuid4(),
                                            json.dumps(job))
         if curr_node_id in node_list:


### PR DESCRIPTION
This patch fixes multi-node import failure
that is currently happening because we are
trying to dump a json that has a python
object.

tendrl-bug-id: Tendrl/node_agent#128
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>