### PR TITLE
Add service detection feature to node agent

### DIFF
--- a/tendrl/node_agent/manager/manager.py
+++ b/tendrl/node_agent/manager/manager.py
@@ -8,6 +8,7 @@ import time
 import gevent.event
 import gevent.greenlet
 import pull_hardware_inventory
+from pull_service_status import TENDRL_SERVICE_TAGS
 
 from tendrl.commons.config import TendrlConfig
 from tendrl.commons.log import setup_logging
@@ -27,6 +28,7 @@ from tendrl.node_agent.persistence.node import Node
 from tendrl.node_agent.persistence.node_context import NodeContext
 from tendrl.node_agent.persistence.os import Os
 from tendrl.node_agent.persistence.persister import NodeAgentEtcdPersister
+from tendrl.node_agent.persistence.service import Service
 from tendrl.node_agent.persistence.tendrl_context import TendrlContext
 
 LOG = logging.getLogger(__name__)
@@ -82,6 +84,18 @@ class NodeAgentSyncStateThread(SyncStateThread):
         LOG.info("%s complete" % self.__class__.__name__)
 
 
+def update_node_context(manager, machine_id, tags=""):
+    manager.persister_thread.update_node_context(
+        NodeContext(
+            updated=str(time.time()),
+            machine_id=machine_id,
+            node_id=utils.set_local_node_context(),
+            fqdn=socket.getfqdn(),
+            tags=tags
+        )
+    )
+
+
 class NodeAgentManager(Manager):
     """manage user request thread
 
@@ -116,14 +130,7 @@ class NodeAgentManager(Manager):
         self.register_node(machine_id)
 
     def register_node(self, machine_id):
-        self.persister_thread.update_node_context(
-            NodeContext(
-                updated=str(time.time()),
-                machine_id=machine_id,
-                node_id=utils.set_local_node_context(),
-                fqdn=socket.getfqdn(),
-            )
-        )
+        update_node_context(self, machine_id)
         tendrl_context = pull_hardware_inventory.getTendrlContext()
         self.persister_thread.update_tendrl_context(
             TendrlContext(
@@ -146,14 +153,18 @@ class NodeAgentManager(Manager):
 
     def on_pull(self, raw_data):
         LOG.info("on_pull, Updating Node_context data")
-        self.persister_thread.update_node_context(
-            NodeContext(
-                updated=str(time.time()),
-                machine_id=raw_data["machine_id"],
-                node_id=raw_data["node_id"],
-                fqdn=raw_data["os"]["FQDN"],
-            )
-        )
+        # Updating the Tags of the node, tags are based on
+        # services running on the node
+        tags = [
+            TENDRL_SERVICE_TAGS[s] for s in raw_data[
+                "services"
+            ].iterkeys() if raw_data["services"][s]["running"]
+        ]
+
+        tag_set = set(tags)
+        tags = ",".join(tag_set)
+        update_node_context(self, utils.get_machine_id(), tags)
+        
         LOG.info("on_pull, Updating node data")
         self.persister_thread.update_node(
             Node(
@@ -239,6 +250,25 @@ class NodeAgentManager(Manager):
                 for disk in disks['free_disks_id']:
                     self.etcd_client.write(("nodes/%s/Disks/free/%s") % (
                         raw_data["node_id"], disk), "")
+        if "services" in raw_data:
+            LOG.info("on_pull, Updating services")
+            try:
+                self.etcd_client.delete(
+                    ("nodes/%s/Services") % raw_data["node_id"],
+                    recursive=True)
+            except etcd.EtcdKeyNotFound as ex:
+                LOG.debug("Given key is not present in etcd . %s", ex)
+
+            for service, value in raw_data["services"].iteritems():
+                self.persister_thread.update_service(
+                    Service(
+                        updated=str(time.time()),
+                        exists=value["exists"],
+                        running=value["running"],
+                        node_id=raw_data["node_id"],
+                        service=service
+                    )
+                )
 
 
 def main():

--- a/tendrl/node_agent/manager/pull_hardware_inventory.py
+++ b/tendrl/node_agent/manager/pull_hardware_inventory.py
@@ -1,6 +1,7 @@
 from command import Command
 import logging
 import platform
+import pull_service_status
 import socket
 from tendrl.node_agent.manager import utils as mgr_utils
 
@@ -342,5 +343,6 @@ def get_node_inventory():
     node_inventory["memory"] = getNodeMemory()
     node_inventory["tendrl_context"] = getTendrlContext()
     node_inventory["disks"] = get_node_disks()
+    node_inventory["services"] = pull_service_status.node_service_details()
 
     return node_inventory

--- a/tendrl/node_agent/manager/pull_service_status.py
+++ b/tendrl/node_agent/manager/pull_service_status.py
@@ -1,0 +1,40 @@
+from tendrl.commons.utils.service_status import ServiceStatus
+
+TENDRL_SERVICE_TAGS = {
+    "tendrl-node-agent": "TENDRL",
+    "etcd": "TENDRL_SERVER",
+    "tendrl-apid": "TENDRL_SERVER",
+    "tendrl-gluster-integration": "TENDRL_GLUSTER",
+    "tendrl-ceph-integration": "TENDRL_CEPH",
+    "glusterd": "GLUSTER",
+    "ceph-mon": "CEPH_MON",
+    "ceph-osd": "CEPH_OSD"
+}
+
+TENDRL_SERVICES = [
+    "tendrl-node-agent",
+    "etcd",
+    "tendrl-apid",
+    "tendrl-gluster-integration",
+    "tendrl-ceph-integration",
+    "glusterd",
+    "ceph-mon@*",
+    "ceph-osd@*",
+
+]
+
+
+def get_service_info(service_name):
+    service = ServiceStatus(service_name)
+    return {"exists": service.exists(), "running": service.status()}
+
+
+def node_service_details():
+    service_detail = {}
+
+    for service in TENDRL_SERVICES:
+        service_info = get_service_info(service)
+        if service_info["exists"]:
+            service_detail[service.rstrip("@*")] = service_info
+
+    return service_detail

--- a/tendrl/node_agent/manager/tendrl_definitions_node_agent.py
+++ b/tendrl/node_agent/manager/tendrl_definitions_node_agent.py
@@ -30,6 +30,16 @@ namespace.tendrl.node_agent:
           type: String
       enabled: true
       value: nodes/$Node_context.node_id/Memory
+    Service:
+      attrs:
+        running:
+          type: String
+        exists:
+          type: String
+        service:
+          type: String
+      enabled: true
+      list: nodes/$Node_context.node_id/Services
     Disk:
       attrs:
         disk_id:
@@ -359,6 +369,9 @@ namespace.tendrl.node_agent:
           type: String
         node_id:
           help: "Tendrl ID for the managed node"
+          type: String
+        tags:
+          help: "The tags associated with this node"
           type: String
       enabled: true
       value: nodes/$Node_context.node_id/Node_context

--- a/tendrl/node_agent/persistence/node_context.py
+++ b/tendrl/node_agent/persistence/node_context.py
@@ -11,6 +11,7 @@ class NodeContext(EtcdObj):
     node_id = fields.StrField("node_id")
     machine_id = fields.StrField("machine_id")
     fqdn = fields.StrField("fqdn")
+    tags = fields.StrField("tags")
 
     def render(self):
         self.__name__ = self.__name__ % self.node_id

--- a/tendrl/node_agent/persistence/persister.py
+++ b/tendrl/node_agent/persistence/persister.py
@@ -15,6 +15,9 @@ class NodeAgentEtcdPersister(EtcdPersister):
     def update_os(self, os):
         self._store.save(os)
 
+    def update_service(self, service):
+        self._store.save(service)
+
     def update_node(self, fqdn):
         self._store.save(fqdn)
 

--- a/tendrl/node_agent/persistence/service.py
+++ b/tendrl/node_agent/persistence/service.py
@@ -1,0 +1,18 @@
+from tendrl.commons.etcdobj.etcdobj import EtcdObj
+from tendrl.commons.etcdobj import fields
+
+
+class Service(EtcdObj):
+    """A table of the service, lazily updated
+
+    """
+    __name__ = 'nodes/%s/Services/%s'
+
+    node_id = fields.StrField("node_id")
+    exists = fields.StrField("exists")
+    running = fields.StrField("running")
+    service = fields.StrField("service")
+
+    def render(self):
+        self.__name__ = self.__name__ % (self.node_id, self.service)
+        return super(Service, self).render()


### PR DESCRIPTION
This patch adds service detection capability to node-agent.
Node-agent will have a list of predefined services, which
it will look out for on the node in which it is running. It
will update etcd with the list of services available and or
running on the node. Also based on if the service is running
it will update the TAGS field in the node_context.

tendrl-bug-id: Tendrl/node_agent#136
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>