### PR TITLE
Added preferred tags for flows

### DIFF
--- a/etc/create_sample_job.py
+++ b/etc/create_sample_job.py
@@ -11,6 +11,7 @@ job = {
     "flow": "ExecuteCommand",
     "object_type": "generic",
     "status": 'new',
+    "targeted_tags": ["tendrl/node"],  # please refer flow defn. for this flow
     "message": 'Executing command',
     "attributes": {
         "_raw_input": "ls"

--- a/tendrl/node_agent/manager/tendrl_definitions_node_agent.py
+++ b/tendrl/node_agent/manager/tendrl_definitions_node_agent.py
@@ -429,6 +429,9 @@ namespace.tendrl.node_agent.gluster_integration:
         - tendrl.node_agent.objects.File.atoms.write
         - tendrl.node_agent.objects.Node.atoms.cmd
       help: "Import existing Gluster Cluster"
+      preferred_tags:
+        - "gluster/server"
+        - "tendrl/node"
       enabled: true
       inputs:
         mandatory:
@@ -506,6 +509,9 @@ namespace.tendrl.node_agent.ceph_integration:
         - tendrl.node_agent.objects.File.atoms.write
         - tendrl.node_agent.objects.Node.atoms.cmd
       help: "Import existing Ceph Cluster"
+      preferred_tags:
+        - "ceph/mon"
+        - "tendrl/node"
       enabled: true
       inputs:
         mandatory:


### PR DESCRIPTION
This patch adds preferred tags to be used for flows
related to node-agent. The jobs that are created for
this flows must use the "preffered_tags" in flow for
adding field "targeted_tags" field in the job. These
jobs will be picked only by nodes having the specified
tags

tendrl-bug-id: Tendrl/node_agent#121
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>