### PR TITLE
Add package source type for installation of bridges

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -59,7 +59,7 @@ enviroment which we have created during installation of *commons*.
 4. Create config file::
 
     $ cp etc/logging.yaml.timedrotation.sample /etc/tendrl/node-agent_logging.yaml
-    $ cp etc/tendrl/tendrl.conf.sample /etc/tendrl/tendrl.conf
+    $ cp etc/tendrl/node-agent/node-agent-dev.conf.yaml /etc/tendrl/node-agent/node-agent.conf.yaml
 
 5. Add suitable configuration in config file by updating following lines to
    tendrl configfile(/etc/tendrl/tendrl.conf)::

--- a/etc/tendrl/node-agent/node-agent-dev.conf.yaml
+++ b/etc/tendrl/node-agent/node-agent-dev.conf.yaml
@@ -4,4 +4,4 @@ etcd_connection: 0.0.0.0
 tendrl_ansible_exec_file: $HOME/.tendrl/node-agent/ansible_exec
 log_cfg_path: /etc/tendrl/node-agent/node-agent_logging.yaml
 log_level: DEBUG
-package_source_type: rpm
+package_source_type: pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ python-etcd
 gevent>=1.0
 greenlet>=0.3.2
 # This is a sub-dependency of ansible, Its not automatically pulled. So explictly pulling this.
-setuptools>=11.3
+setuptools

--- a/tendrl/node_agent/flows/import_cluster/ceph_help.py
+++ b/tendrl/node_agent/flows/import_cluster/ceph_help.py
@@ -5,10 +5,18 @@ import yaml
 
 
 def import_ceph(integration_id):
-    name = "git+https://github.com/Tendrl/ceph_integration.git@v1.2"
-    attributes = {"name": name}
-    attributes["editable"] = "false"
-    ansible_module_path = "core/packaging/language/pip.py"
+    attributes = {}
+    if tendrl_ns.config.data['package_source_type'] == 'pip':
+        name = "git+https://github.com/Tendrl/ceph-integration.git@v1.2"
+        attributes["name"] = name
+        attributes["editable"] = "false"
+        ansible_module_path = "core/packaging/language/pip.py"
+    elif tendrl_ns.config.data['package_source_type'] == 'rpm':
+        name = "tendrl-ceph-integration"
+        ansible_module_path = "core/packaging/os/yum.py"
+        attributes["name"] = name
+    else:
+        return False
 
     try:
         runner = ansible_module_runner.AnsibleRunner(

--- a/tendrl/node_agent/flows/import_cluster/gluster_help.py
+++ b/tendrl/node_agent/flows/import_cluster/gluster_help.py
@@ -5,10 +5,18 @@ import yaml
 
 
 def import_gluster(integration_id):
-    name = "git+https://github.com/Tendrl/gluster_integration.git@v1.2"
-    attributes = {"name": name}
-    attributes["editable"] = "false"
-    ansible_module_path = "core/packaging/language/pip.py"
+    attributes = {}
+    if tendrl_ns.config.data['package_source_type'] == 'pip':
+        name = "git+https://github.com/Tendrl/gluster-integration.git@v1.2"
+        attributes["name"] = name
+        attributes["editable"] = "false"
+        ansible_module_path = "core/packaging/language/pip.py"
+    elif tendrl_ns.config.data['package_source_type'] == 'rpm':
+        name = "tendrl-gluster-integration"
+        ansible_module_path = "core/packaging/os/yum.py"
+        attributes["name"] = name
+    else:
+        return False
 
     try:
         runner = ansible_module_runner.AnsibleRunner(


### PR DESCRIPTION
This patch adds a provision to specify the type of
package source to be considered for installation.

Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>