### PR TITLE
Fix Unavailable gevent.signal.SIGTERM issue

### DIFF
--- a/tendrl/node_agent/manager/__init__.py
+++ b/tendrl/node_agent/manager/__init__.py
@@ -2,6 +2,7 @@ import logging
 
 import etcd
 import gevent
+import signal
 from tendrl.commons import manager as commons_manager
 
 from tendrl.node_agent import node_sync
@@ -90,8 +91,8 @@ def main():
         complete.set()
         m.stop()
 
-    gevent.signal(gevent.signal.SIGTERM, shutdown)
-    gevent.signal(gevent.signal.SIGINT, shutdown)
+    gevent.signal(signal.SIGTERM, shutdown)
+    gevent.signal(signal.SIGINT, shutdown)
 
     while not complete.is_set():
         complete.wait(timeout=1)


### PR DESCRIPTION
Get SIGTERM value form signal module instead of
gevent.signal. Its not available in later

Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>