### PR TITLE
Span the hardware inventory collection over a period of time.

### DIFF
--- a/tendrl/node_agent/manager/__init__.py
+++ b/tendrl/node_agent/manager/__init__.py
@@ -75,6 +75,7 @@ class NodeAgentManager(commons_manager.Manager):
 
 def main():
     tendrl_ns.central_store_thread = central_store.NodeAgentEtcdCentralStore()
+    tendrl_ns.first_node_inventory_sync = True
     tendrl_ns.state_sync_thread = node_sync.NodeAgentSyncThread()
 
     tendrl_ns.node_context.save()

--- a/tendrl/node_agent/node_sync/__init__.py
+++ b/tendrl/node_agent/node_sync/__init__.py
@@ -40,7 +40,12 @@ class NodeAgentSyncThread(sds_sync.StateSyncThread):
 
         while not self._complete.is_set():
             try:
-                gevent.sleep(3)
+                interval = 10
+                if tendrl_ns.first_node_inventory_sync:
+                    interval = 2
+                    tendrl_ns.first_node_inventory_sync = False
+                    
+                gevent.sleep(interval)
                 tags = []
                 # update node agent service details
                 LOG.info("node_sync, Updating Service data")
@@ -49,20 +54,25 @@ class NodeAgentSyncThread(sds_sync.StateSyncThread):
                     if s.running:
                         tags.append(TENDRL_SERVICE_TAGS[service.strip("@*")])
                     s.save()
+                gevent.sleep(interval)
 
                 # updating node context with latest tags
                 LOG.info("node_sync, updating node context data with tags")
                 tags = "\n".join(tags)
                 tendrl_ns.node_agent.objects.NodeContext(tags=tags).save()
+                gevent.sleep(interval)
 
                 LOG.info("node_sync, Updating OS data")
                 tendrl_ns.node_agent.objects.Os().save()
+                gevent.sleep(interval)
 
                 LOG.info("node_sync, Updating cpu")
                 tendrl_ns.node_agent.objects.Cpu().save()
+                gevent.sleep(interval)
 
                 LOG.info("node_sync, Updating memory")
                 tendrl_ns.node_agent.objects.Memory().save()
+                gevent.sleep(interval)
 
                 LOG.info("node_sync, Updating disks")
                 try:


### PR DESCRIPTION
Currently the node inventory is synced every 3 seconds which is very aggressive, considering they change very rarely. So Its better to change the sync interval. Also instead of syncing everything after certain interval (say 5 or 10 mins) of time which causes a huge spike in CPU utilization every time this interval is reached, We can span the inventory collection over a period of time.

 In this patch I have introduced a gevent sleep of 10 secs after collecting every resource. So Its like every resource is updated every 3 minutes once.
tendrl-bug-id: https://github.com/Tendrl/node-agent/issues/198