### PR TITLE
Update node details under clusters

### DIFF
--- a/tendrl/node_agent/__init__.py
+++ b/tendrl/node_agent/__init__.py
@@ -10,6 +10,7 @@ from tendrl.commons import CommonNS
 from tendrl.node_agent.objects.definition import Definition
 from tendrl.node_agent.objects.config import Config
 from tendrl.node_agent.objects.node_context import NodeContext
+from tendrl.node_agent.objects.cluster_node_context import ClusterNodeContext
 from tendrl.node_agent.objects.detected_cluster import DetectedCluster
 from tendrl.node_agent.objects.platform import Platform
 from tendrl.node_agent.objects.tendrl_context import TendrlContext

--- a/tendrl/node_agent/central_store/__init__.py
+++ b/tendrl/node_agent/central_store/__init__.py
@@ -8,6 +8,9 @@ class NodeAgentEtcdCentralStore(central_store.EtcdCentralStore):
     def save_nodecontext(self, node_context):
         tendrl_ns.etcd_orm.save(node_context)
 
+    def save_clusternodecontext(self, cluster_node_context):
+        tendrl_ns.etcd_orm.save(cluster_node_context)
+
     def save_config(self, config):
         tendrl_ns.etcd_orm.save(config)
 

--- a/tendrl/node_agent/objects/cluster_node_context/__init__.py
+++ b/tendrl/node_agent/objects/cluster_node_context/__init__.py
@@ -1,0 +1,70 @@
+import logging
+import os
+import socket
+import uuid
+
+from tendrl.commons.etcdobj import EtcdObj
+from tendrl.commons.utils import cmd_utils
+
+from tendrl.node_agent import objects
+
+
+LOG = logging.getLogger(__name__)
+
+
+class ClusterNodeContext(objects.NodeAgentBaseObject):
+
+    def __init__(self, machine_id=None, node_id=None, fqdn=None,
+                 tags=None, status=None, *args, **kwargs):
+        super(ClusterNodeContext, self).__init__(*args, **kwargs)
+        self.value = 'clusters/%s/nodes/%s/NodeContext'
+        self.machine_id = machine_id or self._get_machine_id()
+        self.node_id = node_id or self._get_node_id() or self._create_node_id()
+        self.fqdn = fqdn or socket.getfqdn()
+        self.tags = tags or ""
+        self.status = status or "UP"
+        self._etcd_cls = _ClusterNodeContextEtcd
+
+    def _get_machine_id(self):
+        cmd = cmd_utils.Command("cat /etc/machine-id")
+        out, err, rc = cmd.run(
+            tendrl_ns.config.data['tendrl_ansible_exec_file'])
+        return str(out)
+
+    def _create_node_id(self, node_id=None):
+        node_id = node_id or str(uuid.uuid4())
+        local_node_context = "/etc/tendrl/node-agent/NodeContext"
+        with open(local_node_context, 'wb+') as f:
+            f.write(node_id)
+            LOG.info("SET_LOCAL: "
+                     "tendrl_ns.node_agent.objects.NodeContext.node_id==%s" %
+                     node_id)
+        return node_id
+
+    def _get_node_id(self):
+        try:
+            local_node_context = "/etc/tendrl/node-agent/NodeContext"
+            if os.path.isfile(local_node_context):
+                with open(local_node_context) as f:
+                    node_id = f.read()
+                    if node_id:
+                        LOG.info(
+                            "GET_LOCAL: tendrl_ns.node_agent.objects.NodeContext"
+                            ".node_id==%s" % node_id)
+                        return node_id
+        except AttributeError:
+            return None
+
+
+class _ClusterNodeContextEtcd(EtcdObj):
+    """A table of the node context, lazily updated
+
+    """
+    __name__ = 'clusters/%s/nodes/%s/NodeContext'
+    _tendrl_cls = ClusterNodeContext
+
+    def render(self):
+        self.__name__ = self.__name__ % (
+            tendrl_ns.tendrl_context.integration_id,
+            tendrl_ns.node_context.node_id)
+        return super(_ClusterNodeContextEtcd, self).render()

--- a/tendrl/node_agent/objects/definition/master.py
+++ b/tendrl/node_agent/objects/definition/master.py
@@ -543,6 +543,28 @@ namespace.tendrl.node_agent:
       list: nodes/$Node_context.node_id/Node_context
       value: nodes/$Node_context.node_id/Node_context
       help: Node Context
+    ClusterNodeContext:
+      attrs:
+        machine_id:
+          help: "Unique /etc/machine-id"
+          type: String
+        fqdn:
+          help: "FQDN of the Tendrl managed node"
+          type: String
+        node_id:
+          help: "Tendrl ID for the managed node"
+          type: String
+        tags:
+          help: "The tags associated with this node"
+          type: String
+        status:
+          help: "Node status"
+          type: String
+
+      enabled: true
+      list: clusters/$TendrlContext.integration_id/nodes/$Node_context.node_id/Node_context
+      value: clusters/$TendrlContext.integration_id/nodes/$Node_context.node_id/Node_context
+      help: Cluster leval Node Context
     File:
       atoms:
         write:


### PR DESCRIPTION
Node agent should update the node details under the
clusters in etcd. Node agent should check if it has
integration id under its tendrl_context, if available
then it should update the node_context for that node
at /clusters/<cluster-id>/nodes/<node-id>/NodeContext

tendrl-bug-id: Tendrl/node-agent#226
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>