### PR TITLE
fix for network interface in node_sync

### DIFF
--- a/tendrl/node_agent/node_sync/__init__.py
+++ b/tendrl/node_agent/node_sync/__init__.py
@@ -147,7 +147,7 @@ class NodeAgentSyncThread(sds_sync.StateSyncThread):
                             # it will delete subnet dir when it is empty
                             # if one entry present then deletion never happen
                             tendrl_ns.etcd_orm.client.delete(network.key, dir=True)
-                        except etcd.EtcdKeyNotFound as ex:
+                        except (etcd.EtcdKeyNotFound, etcd.EtcdDirNotEmpty) as ex:
                             continue
                 except etcd.EtcdKeyNotFound as ex:
                     LOG.debug("Given key is not present in etcd . %s", ex)
@@ -157,7 +157,7 @@ class NodeAgentSyncThread(sds_sync.StateSyncThread):
                             tendrl_ns.node_agent.objects.GlobalNetwork(**interface).save()
                     
 
-            except ValueError as ex:
+            except Exception as ex:
                 LOG.error(ex)
 
         LOG.info("%s complete" % self.__class__.__name__)


### PR DESCRIPTION
etcd.EtcdDirNotEmpty exception handling is missed

Signed-off-by: root <root@dhcp41-178.lab.eng.blr.redhat.com>