### PR TITLE
Added configuration min_reqd_gluster_ver

### DIFF
--- a/etc/tendrl/node-agent/node-agent-dev.conf.yaml
+++ b/etc/tendrl/node-agent/node-agent-dev.conf.yaml
@@ -4,3 +4,6 @@ etcd_connection: 0.0.0.0
 log_cfg_path: /etc/tendrl/node-agent/node-agent_logging.yaml
 log_level: DEBUG
 package_source_type: pip
+min_reqd_gluster_ver: 3.9.0
+tags:
+  - tendrl/node

--- a/etc/tendrl/node-agent/node-agent.conf.yaml.sample
+++ b/etc/tendrl/node-agent/node-agent.conf.yaml.sample
@@ -5,5 +5,6 @@ log_cfg_path: /etc/tendrl/node-agent/node-agent_logging.yaml
 log_level: DEBUG
 package_source_type: rpm
 logging_socket_path: /var/run/tendrl/message.sock
+min_reqd_gluster_ver: 3.9.0
 tags:
-- tendrl/node
+  - tendrl/node


### PR DESCRIPTION
Added the configuration to hold a value of minimum required version
of gluster cluster, which is allowed to be imported within Tendrl.

tendrl-bug-id: Tendrl/gluster-integration#161
Signed-off-by: Shubhendu <shtripat@redhat.com>