### PR TITLE
Fix socket start issue

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include AUTHORS
 include README.rst
 include ChangeLog
 include tendrl-node-agent.service
-include tendrl-message.socket
+include tendrl-node-agent.socket
 include version.py
 exclude .gitignore
 exclude .gitreview

--- a/tendrl-node-agent.service
+++ b/tendrl-node-agent.service
@@ -1,5 +1,7 @@
 [Unit]
 Description= A python agent local to every managed storage node in the sds cluster
+After=tendrl-node-agent.socket
+Requires=tendrl-node-agent.socket
 
 [Service]
 Type=simple

--- a/tendrl-node-agent.service
+++ b/tendrl-node-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description= A python agent local to every managed storage node in the sds cluster
-After=tendrl-node-agent.socket
+After=network.target tendrl-node-agent.socket
 Requires=tendrl-node-agent.socket
 
 [Service]

--- a/tendrl-node-agent.socket
+++ b/tendrl-node-agent.socket
@@ -1,5 +1,6 @@
 [Unit]
 Description=Tendrl message socket for logging
+PartOf=tendrl-node-agent.service
 
 [Socket]
 ListenSequentialPacket=/var/run/tendrl/message.sock

--- a/tendrl-node-agent.spec
+++ b/tendrl-node-agent.spec
@@ -44,7 +44,7 @@ install -m  0755  --directory $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/node-agent
 install -m  0755  --directory $RPM_BUILD_ROOT%{_datadir}/tendrl/node-agent
 install -m  0755  --directory $RPM_BUILD_ROOT%{_sharedstatedir}/tendrl
 install -Dm 0644 tendrl-node-agent.service $RPM_BUILD_ROOT%{_unitdir}/tendrl-node-agent.service
-install -Dm 0644 tendrl-message.socket $RPM_BUILD_ROOT%{_unitdir}/tendrl-message.socket
+install -Dm 0644 tendrl-node-agent.socket $RPM_BUILD_ROOT%{_unitdir}/tendrl-node-agent.socket
 install -Dm 0644 etc/tendrl/node-agent/node-agent.conf.yaml.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/node-agent/node-agent.conf.yaml
 install -Dm 0644 etc/tendrl/node-agent/logging.yaml.syslog.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/node-agent/node-agent_logging.yaml
 install -Dm 644 etc/tendrl/node-agent/*.sample $RPM_BUILD_ROOT%{_datadir}/tendrl/node-agent/
@@ -73,7 +73,7 @@ py.test -v tendrl/node-agent/tests || :
 %{_sysconfdir}/tendrl/node-agent/node-agent.conf.yaml
 %{_sysconfdir}/tendrl/node-agent/node-agent_logging.yaml
 %{_unitdir}/tendrl-node-agent.service
-%{_unitdir}/tendrl-message.socket
+%{_unitdir}/tendrl-node-agent.socket
 
 %changelog
 * Tue Nov 01 2016 Timothy Asir Jeyasingh <tjeyasin@redhat.com> - 0.0.1-1


### PR DESCRIPTION
Socket service will be automatically started/stopped once the
tendrl-node-agent service is started or stopped.

Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>