### PR TITLE
Fix service start issue due to network unavailable

### DIFF
--- a/tendrl-node-agent.service
+++ b/tendrl-node-agent.service
@@ -1,5 +1,7 @@
 [Unit]
 Description= A python agent local to every managed storage node in the sds cluster
+Wants=network-online.target
+After=network.target network-online.target
 Requires=tendrl-node-agent.socket 
 
 [Service]


### PR DESCRIPTION
Update the script to just guarantees that the network service
has been started, Added Order after network target also for
compatibility with older systems

Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>