### PR TITLE
Consider journals already available on SSDs disk while mapping

### DIFF
--- a/tendrl/node_agent/flows/generate_journal_mapping/__init__.py
+++ b/tendrl/node_agent/flows/generate_journal_mapping/__init__.py
@@ -9,7 +9,8 @@ class GenerateJournalMapping(flows.BaseFlow):
     def run(self):
         # Generate the journal mapping for the nodes
         mapping = utils.generate_journal_mapping(
-            self.parameters['Cluster.node_configuration']
+            self.parameters['Cluster.node_configuration'],
+            integration_id=self.parameters.get("TendrlContext.integration_id")
         )
 
         # Update output dict

--- a/tendrl/node_agent/objects/definition/node_agent.yaml
+++ b/tendrl/node_agent/objects/definition/node_agent.yaml
@@ -9,6 +9,8 @@ namespace.node_agent:
       inputs:
         mandatory:
           - Cluster.node_configuration
+        optional:
+          - TendrlContext.integration_id
       run: node_agent.flows.GenerateJournalMapping
       uuid: 3f94a48a-05d7-408c-b400-e27827f4eacc
       type: Create


### PR DESCRIPTION
Intended to invoke the journal mapping calculation wile expand
cluster flow as well. This would consider the already available
journals on any SSD with the node. If maximum no of possible
journals exceed the allowed limit, it would map accordingly.

While invocation from expand cluster flow the caller should pass
TendrlContext.integration_id as well so that existing details can
be considered.

Signed-off-by: Shubhendu <shtripat@redhat.com>