### PR TITLE
Added logic to sync osd journal details while node sync

### DIFF
--- a/tendrl/integrations/ceph/sds_sync/__init__.py
+++ b/tendrl/integrations/ceph/sds_sync/__init__.py
@@ -1,0 +1,82 @@
+import gevent
+import json
+import os
+
+from tendrl.commons.event import Event
+from tendrl.commons.message import Message, ExceptionMessage
+from tendrl.commons.utils import cmd_utils
+from tendrl.commons import sds_sync
+from tendrl.commons.utils import log_utils as logger
+from tendrl.node_agent.node_sync import disk_sync
+
+
+class CephIntegrtaionsSyncThread(sds_sync.StateSyncThread):
+    def _run(self):
+        logger.log(
+            "debug",
+            NS.get("publisher_id", None),
+            {"message": "%s running" % self.__class__.__name__}
+        )
+        if NS.tendrl_context.integration_id is not None:
+            while not self._complete.is_set():
+                # sync of OSD journal details every 30 sec is fine
+                # as this data doesnt change very frequently in cluster
+                gevent.sleep(30)
+                try:
+                    # Sync the OSD journal details
+                    logger.log(
+                        "info",
+                        NS.get("publisher_id", None),
+                        {"message": "ceph_integrations_sync, osd journal details"}
+                    )
+                    journal_details = {}
+                    osd_path = "/var/lib/ceph/osd"
+                    osd_list = os.listdir("/var/lib/ceph/osd")
+
+                    if len(osd_list) > 0:
+                        for item in os.listdir(osd_path):
+                            journal_path = "%s/%s/journal" % (osd_path, item)
+                            out, err, rc = cmd_utils.Command(
+                                "lsblk -o PKNAME,ROTA -n %s" % journal_path
+                            ).run()
+                            if rc != 0:
+                                logger.log(
+                                    "error",
+                                    NS.get("publisher_id", None),
+                                    {"message": "Error getting journal details for OSD. Error: %s" % err}
+                                )
+                            else:
+                                journal_disk, rotational = out.split()
+                                if ("/dev/%s" % journal_disk) in journal_details.keys():
+                                    journal_details[
+                                        "/dev/%s" % journal_disk
+                                    ]['journal_count'] += 1
+                                    journal_details[
+                                        "/dev/%s" % journal_disk
+                                    ]['ssd'] = disk_sync.is_ssd(rotational)
+                                else:
+                                    journal_details["/dev/%s" % journal_disk] = {
+                                        'journal_count': 1,
+                                        'ssd': disk_sync.is_ssd(rotational)
+                                    }
+
+                        NS.integrations.ceph.objects.Journal(
+                            integration_id=NS.tendrl_context.integration_id,
+                            node_id=NS.node_context.node_id,
+                            data=json.dumps(journal_details)
+                        ).save(update=False)
+                except Exception as ex:
+                    logger.log(
+                        "error",
+                        NS.get("publisher_id", None),
+                        {
+                            "message": "ceph integrations sync failed: " + ex.message,
+                            "exception": ex
+                        }
+                    )
+
+            logger.log(
+                "debug",
+                NS.get("publisher_id", None),
+                {"message": "%s complete" % self.__class__.__name__}
+            )

--- a/tendrl/integrations/ceph/sds_sync/__init__.py
+++ b/tendrl/integrations/ceph/sds_sync/__init__.py
@@ -25,7 +25,7 @@ class CephIntegrtaionsSyncThread(sds_sync.StateSyncThread):
                 try:
                     # Sync the OSD journal details
                     logger.log(
-                        "info",
+                        "debug",
                         NS.get("publisher_id", None),
                         {"message": "ceph_integrations_sync, osd journal details"}
                     )

--- a/tendrl/node_agent/manager/__init__.py
+++ b/tendrl/node_agent/manager/__init__.py
@@ -19,6 +19,9 @@ from tendrl.node_agent.message.handler import MessageHandler
 from tendrl.node_agent import node_sync
 from tendrl import provisioning
 
+from tendrl.integrations.ceph import sds_sync as \
+    ceph_integrations_sds_sync
+
 
 class NodeAgentManager(commons_manager.Manager):
     def __init__(self):
@@ -95,6 +98,12 @@ def main():
     m = NodeAgentManager()
     m.start()
 
+    if NS.tendrl_context.sds_name == "ceph" and \
+        NS.tendrl_context.integration_id is not None:
+        NS.ceph_integrations_sync_thread = \
+            ceph_integrations_sds_sync.CephIntegrtaionsSyncThread()
+        NS.ceph_integrations_sync_thread.start()
+
     complete = gevent.event.Event()
 
     def shutdown():
@@ -107,6 +116,9 @@ def main():
         )
         complete.set()
         m.stop()
+        if NS.tendrl_context.sds_name == "ceph" and \
+            NS.tendrl_context.integration_id is not None:
+            NS.ceph_integrations_sync_thread.stop()
     
     def reload_config():
         Event(


### PR DESCRIPTION
This is required if a cluster created from CLI is imported in
tendrl. We should persist the jorunal mapping details in central
store so that while expand cluster these details can be referenced

tendrl-bug-id: Tendrl/ceph-integration#236
Signed-off-by: Shubhendu <shtripat@redhat.com>