### PR TITLE
Disk raw_reference is moved out form etcd disk directory

### DIFF
--- a/tendrl/node_agent/node_sync/disk_sync.py
+++ b/tendrl/node_agent/node_sync/disk_sync.py
@@ -47,7 +47,7 @@ def sync():
             )
         raw_reference = get_raw_reference()
         NS._int.wclient.write(
-            "nodes/%s/LocalStorage/Disks/RawReference" %
+            "nodes/%s/LocalStorage/DiskRawReference" %
             NS.node_context.node_id,
             raw_reference,
             ttl=200,


### PR DESCRIPTION
tendrl-bug-id: Tendrl/node-agent#522

Signed-off-by: GowthamShanmugam <gshanmug@redhat.com>