### PR TITLE
Packaging: snapshot srpm version with timestamp and shortcommit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,6 @@ VERSION := $(shell PYTHONPATH=. python -c \
 RELEASE=1
 COMMIT := $(shell git rev-parse HEAD)
 SHORTCOMMIT := $(shell echo $(COMMIT) | cut -c1-7)
-GIT_RELEASE := $(shell git describe --tags --match 'v*' \
-                 | sed 's/^v//' \
-                 | sed 's/^[^-]*-//' \
-                 | sed 's/-.*//')
 
 all: srpm
 
@@ -29,14 +25,8 @@ rpm: dist
 
 gitversion:
 	# Set version and release to the latest values from Git
-	$(eval VERSION := $(VERSION).dev$(GIT_RELEASE))
-	$(eval RELEASE := $(GIT_RELEASE).$(SHORTCOMMIT))
-	sed -i version.py \
-	  -e "s/^__version__ = .*/__version__ = '$(VERSION)'/"
-	sed -i tendrl-node-agent.spec \
-	  -e "s/^Version: .*/Version: $(VERSION)/"
-	sed -i tendrl-node-agent.spec \
-	  -e "s/^Release: .*/Release: $(RELEASE)/"
+	sed -i $(NAME).spec \
+	  -e "/^Release:/cRelease: $(shell date +"%Y%m%dT%H%M%S").$(SHORTCOMMIT)"
 
 snapshot: gitversion srpm
 

--- a/tendrl-node-agent.spec
+++ b/tendrl-node-agent.spec
@@ -1,6 +1,6 @@
 Name: tendrl-node-agent
 Version: 1.4.2
-Release: 20170802T103155.a39fbbc
+Release: 1%{?dist}
 BuildArch: noarch
 Summary: Module for Tendrl Node Agent
 Source0: %{name}-%{version}.tar.gz

--- a/tendrl-node-agent.spec
+++ b/tendrl-node-agent.spec
@@ -1,6 +1,6 @@
 Name: tendrl-node-agent
 Version: 1.4.2
-Release: 1%{?dist}
+Release: 20170802T103155.a39fbbc
 BuildArch: noarch
 Summary: Module for Tendrl Node Agent
 Source0: %{name}-%{version}.tar.gz


### PR DESCRIPTION
Update makefile for snapshot srpm version to have timestamp
and shortcommit

tendrl-bug-id: Tendrl/node-agent#547
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>