### PR TITLE
Update tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,4 @@ env:
   - TOXENV=pep8
   - TOXENV=check_commit_msg
   - TOXENV=py27-cover-master
-  - TOXENV=py27-cover-develop
   - TOXENV=docs

--- a/requirements.develop.txt
+++ b/requirements.develop.txt
@@ -1,3 +1,0 @@
-# use latest version from develop branch on github
-git+https://github.com/Tendrl/commons.git@develop
--e .

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     cover: codecov
     master: -r{toxinidir}/requirements.master.txt
 commands =
-    python -m pytest --cov=tendrl tendrl/node_agent/tests
+    {envpython} -m pytest --cov=tendrl tendrl/node_agent/tests
     cover: codecov
 
 # Runs PEP8 checks on the source code via flake8 tool

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     cover: codecov
     master: -r{toxinidir}/requirements.master.txt
 commands =
-    {envpython} -m pytest --cov=tendrl tendrl/node_agent/tests
+    {envpython} -m pytest --cov=tendrl {posargs:tendrl/node_agent/tests}
     cover: codecov
 
 # Runs PEP8 checks on the source code via flake8 tool

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@
 
 [tox]
 minversion = 2.0
-# envlist = {py26,py27,py34}-{master,develop},pep8,docs
-envlist = py27-{master,develop},pep8,docs
+# envlist = {py26,py27,py34}-master,pep8,docs
+envlist = py27-master,pep8,docs
 
 # Test env defaults, runs unit tests via pytest.
 # In this case, the "default" means that py34, py27 or other test enviroment
@@ -23,7 +23,6 @@ deps =
     pytest-cov
     cover: codecov
     master: -r{toxinidir}/requirements.master.txt
-    develop: -r{toxinidir}/requirements.develop.txt
 commands =
     python -m pytest --cov=tendrl tendrl/node_agent/tests
     cover: codecov


### PR DESCRIPTION
This pull request keeps tox working as expected:

* integration with develop branch was removed (we no longer use this branch in new workflow)
* it's also possible to pass arguments to pytest via tox (see an example in https://github.com/Tendrl/commons/pull/677)
* we make extra sure that the right python is used during test execution