### PR TITLE
Add sync_interval to node-agent conf file

### DIFF
--- a/etc/tendrl/node-agent/node-agent.conf.yaml.sample
+++ b/etc/tendrl/node-agent/node-agent.conf.yaml.sample
@@ -10,5 +10,6 @@ glusterfs_repo: https://buildlogs.centos.org/centos/7/storage/x86_64/gluster-3.9
 with_internal_profiling: False
 graphite_host: 0.0.0.0
 graphite_port: 2003
+sync_interval: 10
 tags:
   - tendrl/node


### PR DESCRIPTION
This is required for collectd interval configuration as
the configure_monitoring is run by node-agent and sync_interval of
gluster-integration is not accessible to configuration atom.

Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>