### PR TITLE
Fix heal info parsing

### DIFF
--- a/tendrl/node_agent/monitoring/collectd/collectors/gluster/utils.py
+++ b/tendrl/node_agent/monitoring/collectd/collectors/gluster/utils.py
@@ -201,7 +201,8 @@ def parse_get_state(get_state_json):
                                 brick_index
                             )
                         ].split(':')[1],
-                        'connections_count': client_count
+                        'connections_count': client_count,
+                        'brick_index': brick_index
                     }
                     brick_status_key = 'volume%s.brick%s.status' % (
                         vol_index,


### PR DESCRIPTION
The issue was accessing a non-existant key fixed that
by storing brick index in get-state parsed result.
The other issue was in pushing values of bricks from
all nodes which caused the issue of node-name mismatch
when gluster hostname is different from tendrl identified
fqdn

Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>