### PR TITLE
Fix issues

### DIFF
--- a/tendrl/node_agent/monitoring/collectd/templates/gluster/tendrl_gluster_brick_disk_stats.jinja
+++ b/tendrl/node_agent/monitoring/collectd/templates/gluster/tendrl_gluster_brick_disk_stats.jinja
@@ -1,0 +1,15 @@
+<Plugin "python">
+    ModulePath "/usr/lib64/collectd/gluster"
+
+    Import "tendrl_gluster_brick_disk_stats"
+
+    <Module "tendrl_gluster_brick_disk_stats">
+        integration_id "{{integration_id}}"
+        graphite_host "{{ graphite_host }}"
+        graphite_port "{{ graphite_port }}"
+        peer_name "{{ hostname }}"
+        provisioner {{ is_provisioner_node }}
+        etcd_host "{{ etcd_host }}"
+        etcd_port {{ etcd_port }}
+    </Module>
+</Plugin>


### PR DESCRIPTION
This PR fixes the following issues in collectd plugins:

1. Working on stale cluster topology due to which newly added resources
   were not synced properly. This was happening because the topology and
   device tree are static variables intialized statically and not reset.
   So now, the fix is, to intialize it as required.
2. Blivet static reset, resets only once and hence subsequent blivet usages
   don't get the latest data.This PR fixes this

tendrl-bug-id: Tendrl/node-agent#611
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>