### PR TITLE
Added ttl for node status.

### DIFF
--- a/tendrl/node_agent/node_sync/check_all_managed_nodes_status.py
+++ b/tendrl/node_agent/node_sync/check_all_managed_nodes_status.py
@@ -1,0 +1,20 @@
+import etcd
+
+
+def run():
+    try:
+        nodes = NS._int.client.read("/nodes")
+    except etcd.EtcdKeyNotFound:
+        return
+
+    for node in nodes.leaves:
+        node_id = node.key.split('/')[-1]
+        try:
+            NS._int.client.write(
+                "/nodes/{0}/NodeContext/status".format(node_id),
+                "DOWN",
+                prevExist=False
+            )
+        except etcd.EtcdAlreadyExist:
+            pass
+    return

--- a/tendrl/node_agent/node_sync/cluster_contexts_sync.py
+++ b/tendrl/node_agent/node_sync/cluster_contexts_sync.py
@@ -3,7 +3,7 @@ from tendrl.commons.message import ExceptionMessage
 from tendrl.commons.message import Message
 
 
-def sync():
+def sync(sync_ttl):
     try:
         if NS.tendrl_context.integration_id:
             Event(
@@ -37,7 +37,7 @@ def sync():
                 fqdn=NS.node_context.fqdn,
                 status=NS.node_context.status,
                 tags=NS.node_context.tags
-            ).save()
+            ).save(ttl=sync_ttl)
     except Exception as ex:
         Event(
             ExceptionMessage(


### PR DESCRIPTION
This patch adds heartbeat updation during node sync.
If the node goes down due to any reason, the heart
beat object will vanish after some time. Thus API
layer can get to know that node is down and mark it
accordingly.

tendrl-bug-id: Tendrl/node-agent#592
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>