### PR TITLE
Changed the logic to get volume heal info

### DIFF
--- a/tendrl/node_agent/monitoring/collectd/collectors/gluster/heavy_weight/tendrl_gluster_heal_info.py
+++ b/tendrl/node_agent/monitoring/collectd/collectors/gluster/heavy_weight/tendrl_gluster_heal_info.py
@@ -9,121 +9,141 @@ import utils as tendrl_glusterfs_utils
 ret_val = {}
 
 
-def _parse_self_heal_stats(op):
-    info = op.split('Crawl statistics for brick no ')
-    bricks_heal_info = []
-    for i in range(1, len(info)):
-        brick_i_info = info[i].split('\n')
+def _parse_self_heal_info_stats(op):
+    volume_heal_info = {}
+    info = op.split("\n\n")
+    for entry in info[:len(info) - 1]:
         brick_heal_info = {}
-        for idx, line in enumerate(brick_i_info):
-            line = line.strip()
-            if idx == 0:
-                brick_heal_info['brick_index'] = int(line) + 1
-            if 'No. of entries healed' in line:
-                brick_heal_info['healed_cnt'] = int(
-                    line.replace('No. of entries healed: ', '')
-                )
-            if 'No. of entries in split-brain' in line:
-                brick_heal_info['split_brain_cnt'] = int(
-                    line.replace('No. of entries in split-brain: ', '')
-                )
-            if 'No. of heal failed entries' in line:
-                brick_heal_info['heal_failed_cnt'] = int(
-                    line.replace('No. of heal failed entries: ', '')
-                )
-            if 'Hostname of brick ' in line:
-                brick_heal_info['host_name'] = line.replace(
-                    'Hostname of brick ', ''
-                )
-        bricks_heal_info.append(brick_heal_info)
-    return bricks_heal_info
+        brick_name = ""
+        heal_pending_cnt = 0
+        for line in entry.split("\n"):
+            if "Brick " in line:
+                brick_name = line.split(" ")[1]
+            if "Number of entries:" in line:
+                heal_pending_cnt = int(line.split(": ")[1])
+        brick_heal_info['heal_pending_cnt'] = heal_pending_cnt
+        volume_heal_info[brick_name] = brick_heal_info
+
+    return volume_heal_info
 
 
-def get_volume_heal_info(vol):
-    ret_val = []
+def _parse_self_heal_info_split_brain_stats(op):
+    volume_heal_info = {}
+    info = op.split("\n\n")
+    for entry in info[:len(info) - 1]:
+        brick_heal_info = {}
+        brick_name = ""
+        split_brain_cnt = 0
+        for line in entry.split("\n"):
+            if "Brick " in line:
+                brick_name = line.split(" ")[1]
+            if "Number of entries in split-brain:" in line:
+                split_brain_cnt = int(line.split(": ")[1])
+        brick_heal_info['split_brain_cnt'] = split_brain_cnt
+        volume_heal_info[brick_name] = brick_heal_info
+
+    return volume_heal_info
+
+
+def get_volume_heal_info_split_brain_stats(vol):
     for trial_cnt in xrange(0, 3):
         vol_heal_op, vol_heal_err = \
             tendrl_glusterfs_utils.exec_command(
-                "gluster volume heal %s statistics" % vol['name']
+                "gluster volume heal %s info split-brain" % vol['name']
             )
         if vol_heal_err:
             time.sleep(5)
             if trial_cnt == 2:
                 collectd.error(
-                    'Failed to fetch volume heal statistics.'
+                    'Failed to fetch volume heal info split-brain.'
                     'The error is: %s' % (
                         vol_heal_err
                     )
                 )
-                return ret_val
+                return {}
             continue
         else:
             break
     try:
-        vol_heal_info = _parse_self_heal_stats(
+        vol_heal_info = _parse_self_heal_info_split_brain_stats(
             vol_heal_op
         )
-        for idx, brick_heal_info in enumerate(vol_heal_info):
-            for sub_vol_id, sub_vol in vol['bricks'].iteritems():
-                for brick_idx, sub_vol_brick in enumerate(sub_vol):
-                    if (
-                        sub_vol_brick[
-                            'brick_index'
-                        ] == brick_heal_info[
-                            'brick_index'
-                        ]
-                    ) and sub_vol_brick['hostname'] == brick_heal_info["host_name"]:
-                        vol_heal_info[idx][
-                            'brick_path'
-                        ] = sub_vol_brick['path']
-                        ret_val.append(vol_heal_info[idx])
-        return ret_val
+        return vol_heal_info
     except (
         AttributeError,
         KeyError,
         ValueError
     ):
         collectd.error(
-            'Failed to collect volume heal statistics. Error %s' % (
+            'Failed to collect volume heal info split-brain. Error %s' % (
                 traceback.format_exc()
             )
         )
-        return ret_val
+        return {}
+
+
+def get_volume_heal_info_stats(vol):
+    for trial_cnt in xrange(0, 3):
+        vol_heal_op, vol_heal_err = \
+            tendrl_glusterfs_utils.exec_command(
+                "gluster volume heal %s info" % vol['name']
+            )
+        if vol_heal_err:
+            time.sleep(5)
+            if trial_cnt == 2:
+                collectd.error(
+                    'Failed to fetch volume heal info.'
+                    'The error is: %s' % (
+                        vol_heal_err
+                    )
+                )
+                return {}
+            continue
+        else:
+            break
+    try:
+        vol_heal_info = _parse_self_heal_info_stats(
+            vol_heal_op
+        )
+        return vol_heal_info
+    except (
+        AttributeError,
+        KeyError,
+        ValueError
+    ):
+        collectd.error(
+            'Failed to collect volume heal info. Error %s' % (
+                traceback.format_exc()
+            )
+        )
+        return {}
 
 
 def get_heal_info(volume, integration_id):
-    vol_heal_info = get_volume_heal_info(volume)
-    for brick_heal_info in vol_heal_info:
+    vol_heal_info_stats = get_volume_heal_info_stats(volume)
+    vol_heal_info_split_brain_stats = get_volume_heal_info_split_brain_stats(volume)
+    for key, value in vol_heal_info_stats.iteritems():
         t_name = \
-            'clusters.%s.volumes.%s.nodes.%s.bricks.%s.split_brain_cnt'
+            "clusters.%s.volumes.%s.nodes.%s.bricks.%s.heal_pending_cnt"
         ret_val[
             t_name % (
                 integration_id,
                 volume['name'],
-                brick_heal_info['host_name'].replace('.', '_'),
-                brick_heal_info['brick_path'].replace('/', '|')
+                key.split(":")[0].replace('.', '_'),
+                key.split(":")[1].replace('/', '|')
             )
-        ] = brick_heal_info['split_brain_cnt']
+        ] = value['heal_pending_cnt']
+    for key, value in vol_heal_info_split_brain_stats.iteritems():
         t_name = \
-            'clusters.%s.volumes.%s.nodes.%s.bricks.%s.healed_cnt'
+            "clusters.%s.volumes.%s.nodes.%s.bricks.%s.split_brain_cnt"
         ret_val[
             t_name % (
                 integration_id,
                 volume['name'],
-                brick_heal_info['host_name'].replace('.', '_'),
-                brick_heal_info['brick_path'].replace('/', '|')
+                key.split(":")[0].replace('.', '_'),
+                key.split(":")[1].replace('/', '|')
             )
-        ] = brick_heal_info['healed_cnt']
-        t_name = \
-            'clusters.%s.volumes.%s.nodes.%s.bricks.%s.heal_failed_cnt'
-        ret_val[
-            t_name % (
-                integration_id,
-                volume['name'],
-                brick_heal_info['host_name'].replace('.', '_'),
-                brick_heal_info['brick_path'].replace('/', '|')
-            )
-        ] = brick_heal_info['heal_failed_cnt']
+        ] = value['split_brain_cnt']
 
 
 def get_metrics(CLUSTER_TOPOLOGY, CONFIG):


### PR DESCRIPTION
Earlier it was using the command `gluster v heal <volname> statistics`
But the same command is not supported. Changed the logic to use two
command instead
 - gluster v heal <volname> info
 - gluster v heal <volname> info split-brain

These details would be merged and reported as below entries in graphite
 - cluster.{int-d}.volumes.{vol-name}.brick.{brick-name}.heal_pending_cnt
 - cluster.{int-d}.volumes.{vol-name}.brick.{brick-name}.split_brain_cnt

Corresponding changes required in tendrl grafana dashboard to show these
two values instead of `heal_failed_cnt`, `healed_cnt` and `split_brain_cnt`

tendrl-bug-id: Tendrl/node-agent#688
Signed-off-by: Shubhendu <shtripat@redhat.com>