### PR TITLE
Mark brick stopped immediately if node is stopped

### DIFF
--- a/tendrl/integrations/gluster/sds_sync/__init__.py
+++ b/tendrl/integrations/gluster/sds_sync/__init__.py
@@ -63,8 +63,7 @@ class GlusterIntegrtaionsSyncThread(sds_sync.StateSyncThread):
                     for brick in bricks.leaves:
                         try:
                             NS._int.wclient.write("{0}/status".format(brick.key),
-                                                  "Stopped",
-                                                  prevExist=False)
+                                                  "Stopped")
                         except etcd.EtcdAlreadyExist:
                             pass
                         

--- a/tendrl/integrations/gluster/sds_sync/__init__.py
+++ b/tendrl/integrations/gluster/sds_sync/__init__.py
@@ -59,7 +59,6 @@ class GlusterIntegrtaionsSyncThread(sds_sync.StateSyncThread):
                         )
                     )
 
-                    bricks_marked_already = True
                     for brick in bricks.leaves:
                         try:
                             NS._int.wclient.write("{0}/status".format(brick.key),


### PR DESCRIPTION
No need to wait for TTL to delete the brick status and then
default to Stopped. The brick could be marked as stopped for
a node which is marked down in tendrl.

Signed-off-by: Shubhendu <shtripat@redhat.com>