### PR TITLE
Use NodeContext.fqdn in collectd plugins

### DIFF
--- a/tendrl/node_agent/monitoring/collectd/templates/node/collectd.jinja
+++ b/tendrl/node_agent/monitoring/collectd/templates/node/collectd.jinja
@@ -1,4 +1,5 @@
-Hostname "{{ hostname }}"
+Hostname "{{ fqdn }}"
+FQDNLookup false
 BaseDir "/var/lib/collectd"
 PluginDir "{{ moduledirconfig }}"
 
@@ -22,10 +23,6 @@ LoadPlugin "aggregation"
   SocketGroup "{{ socketgroup }}"
   SocketPerms "0770"
   DeleteSocket true
-</Plugin>
-
-<Plugin "exec">
-    NotificationExec "tendrl-user" "{{ moduledirconfig }}handle_collectd_notification.py"
 </Plugin>
 
 Include "/etc/collectd.d/*.conf"


### PR DESCRIPTION
tendrl-bug-id: Tendrl/node-agent#766

Collectd has its own logic of finding short name,
ip or fqdn for a node while running its default plugins like cpu, disk etc

We need to add below config options to collectd.conf

1) FQDNLookup false


Also removes unusd legacy code from USM2 (Skyrings)
https://github.com/skyrings/skynet/blob/master/src/collectd_scripts/handle_collectd_notification.py