### PR TITLE
Fixing collectd plugin to push brick details when brick hostname and peer hostname not match

### DIFF
--- a/tendrl/node_agent/monitoring/collectd/collectors/gluster/low_weight/tendrl_glusterfs_brick_utilization.py
+++ b/tendrl/node_agent/monitoring/collectd/collectors/gluster/low_weight/tendrl_glusterfs_brick_utilization.py
@@ -224,10 +224,10 @@ class TendrlBrickUtilizationPlugin(
                     # Check if current brick is from localhost else utilization
                     # of brick from some other host can't be computed here..
                     if (
-                        brick_hostname == socket.gethostbyname(
+                        socket.gethostbyname(brick_hostname) ==
+                        socket.gethostbyname(
                             self.CONFIG['peer_name']
-                        ) or
-                        brick_hostname == self.CONFIG['peer_name']
+                        )
                     ):
                         thread = threading.Thread(
                             target=self.calc_brick_utilization,


### PR DESCRIPTION

tendrl-bug-id: Tendrl/node-agent#769

Signed-off-by: Gowthamshanmugasundaram <gshanmug@redhat.com>