### PR TITLE
Flag for monitoring-integration is assigned by node-agent

### DIFF
--- a/tendrl/node_agent/discovery/sds/plugins/discover_gluster_sds_details.py
+++ b/tendrl/node_agent/discovery/sds/plugins/discover_gluster_sds_details.py
@@ -23,7 +23,7 @@ class DiscoverGlusterStorageSystem(DiscoverSDSPlugin):
                 NS.publisher_id,
                 {"message": _msg}
             )
-            return ""
+            return "", {}
         lines = out.split('\n')[1:]
         gfs_peers_uuid = []
         gfs_peer_data = {}

--- a/tendrl/node_agent/node_sync/services_and_index_sync.py
+++ b/tendrl/node_agent/node_sync/services_and_index_sync.py
@@ -15,6 +15,7 @@ TENDRL_SERVICES = [
     "etcd",
     "tendrl-api",
     "tendrl-gluster-integration",
+    "tendrl-monitoring-integration",
     "glusterd",
 ]
 


### PR DESCRIPTION
flag is assigned in common but it not assigned for server

tendrl-bug-id : Tendrl/node-agent#804
bugzilla: 1570048

Signed-off-by: GowthamShanmugasundaram <gshanmug@redhat.com>