### PR TITLE
Claim provisioner tag only by managed nodes if cluster is managed

### DIFF
--- a/tendrl/node_agent/node_sync/services_and_index_sync.py
+++ b/tendrl/node_agent/node_sync/services_and_index_sync.py
@@ -50,7 +50,7 @@ def sync(sync_ttl=None):
             _tag = "provisioner/%s" % _cluster.integration_id
             _is_new_provisioner = False
             NS.node_context = NS.tendrl.objects.NodeContext().load()
-            _cnc = None,
+            _cnc = None
             _cnc_is_managed = False
             if NS.tendrl.objects.ClusterNodeContext(
                 node_id=NS.node_context.node_id

--- a/tendrl/node_agent/node_sync/services_and_index_sync.py
+++ b/tendrl/node_agent/node_sync/services_and_index_sync.py
@@ -50,19 +50,44 @@ def sync(sync_ttl=None):
             _tag = "provisioner/%s" % _cluster.integration_id
             _is_new_provisioner = False
             NS.node_context = NS.tendrl.objects.NodeContext().load()
-            if _tag not in NS.node_context.tags:
-                try:
-                    _index_key = "/indexes/tags/%s" % _tag
-                    _node_id = json.dumps([NS.node_context.node_id])
-                    etcd_utils.write(
-                        _index_key, _node_id,
-                        prevExist=False
-                    )
-                    etcd_utils.refresh(_index_key, sync_ttl + 50)
-                    tags.append(_tag)
-                    _is_new_provisioner = True
-                except etcd.EtcdAlreadyExist:
-                    pass
+            _cnc = None,
+            _cnc_is_managed = False
+            if NS.tendrl.objects.ClusterNodeContext(
+                node_id=NS.node_context.node_id
+            ).exists():
+                _cnc = NS.tendrl.objects.ClusterNodeContext(
+                    node_id=NS.node_context.node_id
+                ).load()
+                if _cnc.is_managed == "yes":
+                    _cnc_is_managed = True
+            if _cluster.is_managed in [None, '', 'no']:
+                if _tag not in NS.node_context.tags:
+                    try:
+                        _index_key = "/indexes/tags/%s" % _tag
+                        _node_id = json.dumps([NS.node_context.node_id])
+                        etcd_utils.write(
+                            _index_key, _node_id,
+                            prevExist=False
+                        )
+                        etcd_utils.refresh(_index_key, sync_ttl + 50)
+                        tags.append(_tag)
+                        _is_new_provisioner = True
+                    except etcd.EtcdAlreadyExist:
+                        pass
+            else:
+                if _tag not in NS.node_context.tags and _cnc_is_managed:
+                    try:
+                        _index_key = "/indexes/tags/%s" % _tag
+                        _node_id = json.dumps([NS.node_context.node_id])
+                        etcd_utils.write(
+                            _index_key, _node_id,
+                            prevExist=False
+                        )
+                        etcd_utils.refresh(_index_key, sync_ttl + 50)
+                        tags.append(_tag)
+                        _is_new_provisioner = True
+                    except etcd.EtcdAlreadyExist:
+                        pass
 
         # updating node context with latest tags
         logger.log(


### PR DESCRIPTION
In case cluster is un-managed, any node ideally should be able to
claim the provisioner tag. But if cluster is managed and there are
new nodes for expansion in the cluster, only the managed nodes should
be able to claim the provisioner as new nodes if claim the same there
would be issue while expansion of the cluster.

tendrl-bug-id: Tendrl/node-agent#840
bugzilla: 1599634
Signed-off-by: Shubhendu <shtripat@redhat.com>